### PR TITLE
ImportError with PyPDF2 >= 2.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,8 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: docker://python:3.6-stretch
-      uses: docker://python:3.6-stretch
+    - name: docker://python:3.8-bullseye
+      uses: docker://python:3.8-bullseye
       with:
           entrypoint: /bin/bash
           args: -c "/github/workspace/scripts/bootstrap.sh && /github/workspace/scripts/run_tests.sh"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-slim
+FROM python:3.8-slim
 
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
@@ -23,7 +23,7 @@ RUN \
 
 RUN \
 	echo "Install global pip packages" \
-	&& pip install \
-		virtualenv
+	&& python -m pip install --upgrade pip \
+	   pip install virtualenv
 
 WORKDIR /var/project

--- a/notifications_utils/pdf.py
+++ b/notifications_utils/pdf.py
@@ -1,6 +1,6 @@
 import PyPDF2
 from PyPDF2 import PdfFileWriter
-from PyPDF2.utils import PdfReadError
+from PyPDF2.errors import PdfReadError
 import io
 
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,3 +1,1 @@
-__version__ = '1.0.66'
-# GDS version '34.0.1'
-# CDS version '41.0.0'
+__version__ = '1.1.0'

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,10 +1,11 @@
 -r requirements.txt
-phonenumbers==8.12.12
-pytest==5.1.2
-pytest-mock==1.10.4
-pytest-cov==2.10.1
-pytest-xdist==1.29.0
-requests-mock==1.8.0
-freezegun==1.0.0
+
 flake8==3.7.8
 flake8-print==3.1.4
+freezegun==1.0.0
+phonenumbers==8.12.12
+pytest==5.1.2
+pytest-cov==2.10.1
+pytest-mock==1.10.4
+pytest-xdist==1.29.0
+requests-mock==1.8.0

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 #
-# Bootstrap virtualenv environment and postgres databases locally.
-#
-# NOTE: This script expects to be run from the project root with
-# ./scripts/bootstrap.sh
+# NOTE: This script expects to be run from the project root with ./scripts/bootstrap.sh.
 
 set -o pipefail
 
@@ -20,5 +17,5 @@ function display_result {
   fi
 }
 
-# Install Python development dependencies
+# Install the Python development dependencies.
 pip3 install -r requirements_for_test.txt

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'pytz>=2021.3',
         'smartypants>=2.0.1',
         'monotonic>=1.6',
-        'pypdf2>=1.26.0',
+        'pypdf2>=2.0.0',
 
         # required by both api and admin
         'awscli',

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -3,7 +3,7 @@ from io import BytesIO
 
 import PyPDF2
 import pytest
-from PyPDF2.utils import PdfReadError
+from PyPDF2.errors import PdfReadError
 
 from notifications_utils.pdf import pdf_page_count, extract_page_from_pdf
 from tests.pdf_consts import one_page_pdf, multi_page_pdf, not_pdf


### PR DESCRIPTION
#84 

Upgrade the PyPDF2 dependency to >=2.0.0.  Utilize Python 3.8 with continuous integration.

After I merge these changes, I will follow the steps in the README to create a new tag and reference that tag in the requirements-app.txt file of notification-api.