### PR TITLE
#108 phonenumbers.PhoneNumberMatcher does not correctly parse a phone number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setup(
         'monotonic>=1.6',
         'orderedset>=2.0.3',
         'phonenumbers~=8.12.12',
-        'pypdf2>=2.0.0',
+        # PyPDF2 >= 3.0 removes deprecated features, which breaks this repo.
+        'pypdf2~=2.12.1',
         'python-json-logger>=0.1.11',
         'pytz>=2021.3',
         'pyyaml==5.4.1',


### PR DESCRIPTION
Fixes #108.  Also see https://github.com/daviddrysdale/python-phonenumbers/issues/257, which is the upstream issue these changes work around.

These changes should be merged into a 1.0.x branch as well as master because [notification-api still depends on the former](https://github.com/department-of-veterans-affairs/notification-api/blob/master/requirements-app.txt).