### PR TITLE
Phone number validation error handling

### DIFF
--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -396,10 +396,10 @@ def validate_phone_number(number, column=None, international=False):  # noqa:   
 
     if not normalized_number:
         try:
-            parsedNumber = phonenumbers.parse(number, region_code)
-            isValidNumber = phonenumbers.is_valid_number(parsedNumber)
-            if not isValidNumber:
-                logging.warning('Failed to validate parsed number: %s,', parsedNumber)
+            parsed_number = phonenumbers.parse(number, region_code)
+            is_valid_number = phonenumbers.is_valid_number(parsed_number)
+            if not is_valid_number:
+                logging.warning('Failed to validate parsed number: %s,', parsed_number)
                 raise InvalidPhoneError(
                     'Field contains an invalid number due to either formatting '
                     'or an impossible combination of area code and/or telephone prefix.'

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -399,7 +399,7 @@ def validate_phone_number(number, column=None, international=False):  # noqa:   
             parsed_number = phonenumbers.parse(number, region_code)
             is_valid_number = phonenumbers.is_valid_number(parsed_number)
             if not is_valid_number:
-                logging.warning('Failed to validate parsed number: %s,', parsed_number)
+                logging.warning('Failed to validate parsed number: %s', parsed_number)
                 raise InvalidPhoneError(
                     'Field contains an invalid number due to either formatting '
                     'or an impossible combination of area code and/or telephone prefix.'

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -394,18 +394,24 @@ def validate_phone_number(number, column=None, international=False):
     if (not international) or is_local_phone_number(number):
         return validate_local_phone_number(number)
 
-    number = normalise_phone_number(number)
+    normalized_number = normalise_phone_number(number)
 
-    if number is False:
-        raise InvalidPhoneError('Not a valid international number')
+    if normalized_number is False:
+        try:
+            parsedNumber = phonenumbers.parse(number, region_code)
+            isValidNumber = phonenumbers.is_valid_number(parsedNumber)
+            if (isValidNumber is False):
+                raise InvalidPhoneError("Possibly number but strictly this is not valid")
+        except phonenumbers.phonenumberutil.NumberParseException:
+            raise InvalidPhoneError('Not a valid international number')
 
-    if len(number) < 8:
+    if len(normalized_number) < 8:
         raise InvalidPhoneError('Not enough digits')
 
-    if get_international_prefix(number) is None:
+    if get_international_prefix(normalized_number) is None:
         raise InvalidPhoneError('Not a valid country prefix')
 
-    return number
+    return normalized_number
 
 
 validate_and_format_phone_number = validate_phone_number

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -401,6 +401,7 @@ def validate_phone_number(number, column=None, international=False):  # noqa:   
             parsedNumber = phonenumbers.parse(number, region_code)
             isValidNumber = phonenumbers.is_valid_number(parsedNumber)
             if not isValidNumber:
+                current_app.logger.exception('%s: This number is not accpeted', number)
                 raise InvalidPhoneError(
                     'Field contains an invalid number due to either formatting '
                     'or an impossible combination of area code and/or telephone prefix.'

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -396,11 +396,11 @@ def validate_phone_number(number, column=None, international=False):  # noqa:   
 
     normalized_number = normalise_phone_number(number)
 
-    if normalized_number is False:
+    if not normalized_number:
         try:
             parsedNumber = phonenumbers.parse(number, region_code)
             isValidNumber = phonenumbers.is_valid_number(parsedNumber)
-            if (isValidNumber is False):
+            if not isValidNumber:
                 raise InvalidPhoneError(
                     'Field contains an invalid number due to either formatting '
                     'or animpossible combination of area code and/or telephone prefix.'

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import sys
 import csv
@@ -9,9 +10,6 @@ from functools import lru_cache, partial
 from itertools import islice
 from collections import OrderedDict, namedtuple
 from orderedset import OrderedSet
-
-from flask import current_app
-
 from . import EMAIL_REGEX_PATTERN, hostname_part, tld_part
 from notifications_utils.formatters import strip_and_remove_obscure_whitespace, strip_whitespace
 from notifications_utils.template import Template
@@ -401,7 +399,7 @@ def validate_phone_number(number, column=None, international=False):  # noqa:   
             parsedNumber = phonenumbers.parse(number, region_code)
             isValidNumber = phonenumbers.is_valid_number(parsedNumber)
             if not isValidNumber:
-                current_app.logger.exception('%s: This number is not accpeted', number)
+                logging.error('%s: This number is not accpeted', number)
                 raise InvalidPhoneError(
                     'Field contains an invalid number due to either formatting '
                     'or an impossible combination of area code and/or telephone prefix.'
@@ -430,7 +428,7 @@ def try_validate_and_format_phone_number(number, column=None, international=None
         return validate_and_format_phone_number(number, column, international)
     except InvalidPhoneError as exc:
         if log_msg:
-            current_app.logger.warning('{}: {}'.format(log_msg, exc))
+            logging.warning('{}: {}'.format(log_msg, exc))
         return number
 
 

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -403,7 +403,7 @@ def validate_phone_number(number, column=None, international=False):  # noqa:   
             if (isValidNumber is False):
                 raise InvalidPhoneError("Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.")
         except phonenumbers.phonenumberutil.NumberParseException:
-            raise InvalidPhoneError('Not a valid international number')
+            raise InvalidPhoneError('Not a valid number')
 
     if len(normalized_number) < 8:
         raise InvalidPhoneError('Not enough digits')

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -401,7 +401,10 @@ def validate_phone_number(number, column=None, international=False):  # noqa:   
             parsedNumber = phonenumbers.parse(number, region_code)
             isValidNumber = phonenumbers.is_valid_number(parsedNumber)
             if (isValidNumber is False):
-                raise InvalidPhoneError("Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.")
+                raise InvalidPhoneError(
+                    'Field contains an invalid number due to either formatting '
+                    'or animpossible combination of area code and/or telephone prefix.'
+                )
         except phonenumbers.phonenumberutil.NumberParseException:
             raise InvalidPhoneError('Not a valid number')
 

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -399,7 +399,7 @@ def validate_phone_number(number, column=None, international=False):  # noqa:   
             parsedNumber = phonenumbers.parse(number, region_code)
             isValidNumber = phonenumbers.is_valid_number(parsedNumber)
             if not isValidNumber:
-                logging.error('%s: This number is not accpeted', number)
+                logging.warning('Failed to validate parsed number: %s,', parsedNumber)
                 raise InvalidPhoneError(
                     'Field contains an invalid number due to either formatting '
                     'or an impossible combination of area code and/or telephone prefix.'
@@ -428,7 +428,8 @@ def try_validate_and_format_phone_number(number, column=None, international=None
         return validate_and_format_phone_number(number, column, international)
     except InvalidPhoneError as exc:
         if log_msg:
-            logging.warning('{}: {}'.format(log_msg, exc))
+            logging.warning(log_msg)
+            logging.exception(exc)
         return number
 
 

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -401,7 +401,7 @@ def validate_phone_number(number, column=None, international=False):  # noqa:   
             parsedNumber = phonenumbers.parse(number, region_code)
             isValidNumber = phonenumbers.is_valid_number(parsedNumber)
             if (isValidNumber is False):
-                raise InvalidPhoneError("Possibly number but strictly this is not valid")
+                raise InvalidPhoneError("Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.")
         except phonenumbers.phonenumberutil.NumberParseException:
             raise InvalidPhoneError('Not a valid international number')
 

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -386,7 +386,7 @@ def validate_local_phone_number(number, column=None):
         raise InvalidPhoneError('Not a valid local number')
 
 
-def validate_phone_number(number, column=None, international=False):
+def validate_phone_number(number, column=None, international=False):  # noqa:   C901
 
     if ';' in number:
         raise InvalidPhoneError('Not a valid number')

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -403,7 +403,7 @@ def validate_phone_number(number, column=None, international=False):  # noqa:   
             if not isValidNumber:
                 raise InvalidPhoneError(
                     'Field contains an invalid number due to either formatting '
-                    'or animpossible combination of area code and/or telephone prefix.'
+                    'or an impossible combination of area code and/or telephone prefix.'
                 )
         except phonenumbers.phonenumberutil.NumberParseException:
             raise InvalidPhoneError('Not a valid number')

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'monotonic>=1.6',
         'orderedset>=2.0.3',
         'phonenumbers~=8.12.12',
-        'pypdf2>=2.0.0',
+        'pypdf2 < 3.0.0',
         'python-json-logger>=0.1.11',
         'pytz>=2021.3',
         'pyyaml==5.4.1',

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -84,28 +84,28 @@ invalid_phone_numbers = [
         '800000000000',
         (
             'Field contains an invalid number due to either formatting '
-            'or animpossible combination of area code and/or telephone prefix.'
+            'or an impossible combination of area code and/or telephone prefix.'
         )
     ),
     (
         '1234567',
         (
             'Field contains an invalid number due to either formatting '
-            'or animpossible combination of area code and/or telephone prefix.'
+            'or an impossible combination of area code and/or telephone prefix.'
         )
     ),
     (
         '+682 1234',
         (
             'Field contains an invalid number due to either formatting '
-            'or animpossible combination of area code and/or telephone prefix.'
+            'or an impossible combination of area code and/or telephone prefix.'
         )
     ),  # Cook Islands phone numbers can be 5 digits
     (
         '+17553927664',
         (
             'Field contains an invalid number due to either formatting '
-            'or animpossible combination of area code and/or telephone prefix.'
+            'or an impossible combination of area code and/or telephone prefix.'
         )
     ),
 ]

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -435,7 +435,7 @@ def test_format_recipient(recipient, expected_formatted):
 
 
 def test_try_format_recipient_doesnt_throw():
-    assert try_validate_and_format_phone_number('ALPHANUM3R1C') == 'ALPHANUM3R1C'
+    assert try_validate_and_format_phone_number('ALPHANUM3R1C', log_msg="Log this.") == 'ALPHANUM3R1C'
 
 
 def test_format_phone_number_human_readable_doenst_throw():

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -80,7 +80,7 @@ invalid_local_phone_numbers = sum([
 invalid_phone_numbers = [
     ('+21 4321 0987', 'Not a valid number'),
     ('+003997 1234 7890', 'Not a valid number'),
-    ('800000000000', 'field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'),
+    ('800000000000', 'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'),
     ('1234567', 'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'),
     ('+682 1234', 'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'),  # Cook Islands phone numbers can be 5 digits
     ('+17553927664', 'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'),

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -78,9 +78,12 @@ invalid_local_phone_numbers = sum([
 
 
 invalid_phone_numbers = [
-    ('800000000000', 'Not a valid international number'),
-    ('1234567', 'Not a valid international number'),
-    ('+682 1234', 'Not a valid international number'),  # Cook Islands phone numbers can be 5 digits
+    ('+21 4321 0987', 'Not a valid international number'),
+    ('+003997 1234 7890', 'Not a valid international number'),
+    ('800000000000', 'Possibly number but strictly this is not valid'),
+    ('1234567', 'Possibly number but strictly this is not valid'),
+    ('+682 1234', 'Possibly number but strictly this is not valid'),  # Cook Islands phone numbers can be 5 digits
+    ('+17553927664', 'Possibly number but strictly this is not valid'),
 ]
 
 
@@ -197,7 +200,7 @@ def test_normalise_phone_number_raises_if_unparseable_characters(phone_number):
 
 @pytest.mark.parametrize('phone_number', [
     '+21 4321 0987',
-    '00997 1234 7890',
+    '+003997 1234 7890',
 ])
 def test_get_international_info_raises(phone_number):
     with pytest.raises(InvalidPhoneError) as error:

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -78,12 +78,12 @@ invalid_local_phone_numbers = sum([
 
 
 invalid_phone_numbers = [
-    ('+21 4321 0987', 'Not a valid international number'),
-    ('+003997 1234 7890', 'Not a valid international number'),
-    ('800000000000', 'Possibly number but strictly this is not valid'),
-    ('1234567', 'Possibly number but strictly this is not valid'),
-    ('+682 1234', 'Possibly number but strictly this is not valid'),  # Cook Islands phone numbers can be 5 digits
-    ('+17553927664', 'Possibly number but strictly this is not valid'),
+    ('+21 4321 0987', 'Not a valid number'),
+    ('+003997 1234 7890', 'Not a valid number'),
+    ('800000000000', 'field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'),
+    ('1234567', 'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'),
+    ('+682 1234', 'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'),  # Cook Islands phone numbers can be 5 digits
+    ('+17553927664', 'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'),
 ]
 
 

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -82,19 +82,31 @@ invalid_phone_numbers = [
     ('+003997 1234 7890', 'Not a valid number'),
     (
         '800000000000',
-        'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'
+        (
+            'Field contains an invalid number due to either formatting '
+            'or animpossible combination of area code and/or telephone prefix.'
+        )
     ),
     (
         '1234567',
-        'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'
+        (
+            'Field contains an invalid number due to either formatting '
+            'or animpossible combination of area code and/or telephone prefix.'
+        )
     ),
     (
         '+682 1234',
-        'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'
+        (
+            'Field contains an invalid number due to either formatting '
+            'or animpossible combination of area code and/or telephone prefix.'
+        )
     ),  # Cook Islands phone numbers can be 5 digits
     (
         '+17553927664',
-        'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'
+        (
+            'Field contains an invalid number due to either formatting '
+            'or animpossible combination of area code and/or telephone prefix.'
+        )
     ),
 ]
 

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -80,10 +80,22 @@ invalid_local_phone_numbers = sum([
 invalid_phone_numbers = [
     ('+21 4321 0987', 'Not a valid number'),
     ('+003997 1234 7890', 'Not a valid number'),
-    ('800000000000', 'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'),
-    ('1234567', 'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'),
-    ('+682 1234', 'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'),  # Cook Islands phone numbers can be 5 digits
-    ('+17553927664', 'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'),
+    (
+        '800000000000',
+        'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'
+    ),
+    (
+        '1234567',
+        'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'
+    ),
+    (
+        '+682 1234',
+        'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'
+    ),  # Cook Islands phone numbers can be 5 digits
+    (
+        '+17553927664',
+        'Field contains an invalid number due to either formatting or an impossible combination of area code and/or telephone prefix.'
+    ),
 ]
 
 
@@ -205,7 +217,7 @@ def test_normalise_phone_number_raises_if_unparseable_characters(phone_number):
 def test_get_international_info_raises(phone_number):
     with pytest.raises(InvalidPhoneError) as error:
         get_international_phone_info(phone_number)
-    assert str(error.value) == 'Not a valid international number'
+    assert str(error.value) == 'Not a valid number'
 
 
 @pytest.mark.parametrize("phone_number", valid_local_phone_numbers)


### PR DESCRIPTION
[#108](https://github.com/department-of-veterans-affairs/notification-utils/issues/108)

Summary
- Catching the error and log the message with the invalid phone number even though it has been parsed. (e.g. +17553927664 is parsed but it is not valid phone number)
- Update PyPDF version.