### PR TITLE
#111 #115 Logger errors hotfix

### DIFF
--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -183,7 +183,7 @@ class CustomLogFormatter(logging.Formatter):
         record = self.add_fields(record)
         try:
             record.msg = str(record.msg).format(**record.__dict__)
-        except (KeyError, IndexError) as e:
+        except Exception as e:
             logger.exception("failed to format log message: {} not found".format(e))
         return super(CustomLogFormatter, self).format(record)
 
@@ -200,6 +200,6 @@ class JSONFormatter(BaseJSONFormatter):
         log_record['logType'] = "application"
         try:
             log_record['message'] = log_record['message'].format(**log_record)
-        except (KeyError, IndexError) as e:
+        except Exception as e:
             logger.exception("failed to format log message: {} not found".format(e))
         return log_record


### PR DESCRIPTION
This is a hotfix to catch all exceptions associated with logging.  It does not address why exceptions are being raised.

#111
#115

## Additional Info

For the prospective definitive fix, see [PR 118](https://github.com/department-of-veterans-affairs/notification-utils/pull/118).