### PR TITLE
#146 - Set default log level for non-prod environment to DEBUG

### DIFF
--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -88,7 +88,7 @@ def init_app(app, statsd_client=None):
     loggers = [app.logger, logging.getLogger('utils')]
     for the_logger, handler in product(loggers, [the_handler]):
         the_logger.addHandler(handler)
-        the_logger.setLevel(loglevel)
+        the_logger.setLevel(logging.INFO)
     logging.getLogger('boto3').setLevel(logging.WARNING)
     logging.getLogger('s3transfer').setLevel(logging.WARNING)
     app.logger.info("Logging configured")

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -50,7 +50,7 @@ def init_app(app, statsd_client=None):
     else:
       app.config.setdefault('NOTIFY_LOG_LEVEL', 'DEBUG')
     
-    print("NOTIFCATION-UTILS WHAT IS NOTIFY_ENVIRONMENT", app.config['NOTIFY_ENVIRONMENT'] )
+    print("NOTIFCATION-UTILS WHAT IS NOTIFY_ENVIRONMENT", os.environ['NOTIFY_ENVIRONMENT'])
     print("NOTIFICATION-UTILS WHAT IS NOTIFY_LOG_LEVEL", app.config['NOTIFY_LOG_LEVEL'] )
   
     app.config.setdefault('NOTIFY_APP_NAME', 'none')

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -114,11 +114,6 @@ def is_200_static_log(log) -> bool:
 
 def get_handler(app):
     stream_handler = logging.StreamHandler(sys.stdout)
-    
-    if app.config['NOTIFY_ENVIRONMENT'] == 'production':
-      app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
-    else:
-      app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
 
     stream_handler.setLevel(logging.getLevelName(app.config['NOTIFY_LOG_LEVEL']))
     stream_handler.addFilter(AppNameFilter(app.config['NOTIFY_APP_NAME']))

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -42,6 +42,7 @@ def build_statsd_line(extra_fields):
 
 
 def init_app(app, statsd_client=None):
+    return False
     app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
     app.config.setdefault('NOTIFY_APP_NAME', 'none')
     app.config.setdefault('NOTIFY_LOG_PATH', './log/application.log')

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -1,4 +1,3 @@
-from email.mime import application
 import logging
 import os
 import sys

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from pythonjsonlogger.jsonlogger import JsonFormatter
 from time import monotonic
 
-
 # The "application" and "requestId" fields are non-standard LogRecord attributes added below in the
 # "get_handler" function via filters.  If this causes errors, logging is misconfigured.
 #     https://docs.python.org/3.8/library/logging.html#logrecord-attributes
@@ -43,14 +42,8 @@ def build_statsd_line(extra_fields):
 
 
 def init_app(app, statsd_client=None):
+    set_log_level(app)
 
-    # For production environment, set log level to INFO 
-    # For all other environment, set log level to DEBUG
-    if os.environ['NOTIFY_ENVIRONMENT'] == 'production':
-      app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
-    else:
-      app.config.setdefault('NOTIFY_LOG_LEVEL', 'DEBUG')
-  
     app.config.setdefault('NOTIFY_APP_NAME', 'none')
     app.config.setdefault('NOTIFY_LOG_PATH', './log/application.log')
 
@@ -96,7 +89,16 @@ def init_app(app, statsd_client=None):
     logging.getLogger('boto3').setLevel(logging.WARNING)
     logging.getLogger('s3transfer').setLevel(logging.WARNING)
 
-    app.logger.info("Logging configured. The log level has been set to %s", app.logger.level) 
+    app.logger.info("Logging configured. The log level has been set to %s", app.logger.level)
+
+
+def set_log_level(app):
+    # For production environment, set log level to INFO
+    # For all other environment, set log level to DEBUG
+    if os.environ['NOTIFY_ENVIRONMENT'] == 'production':
+        app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
+    else:
+        app.config.setdefault('NOTIFY_LOG_LEVEL', 'DEBUG')
 
 
 def ensure_log_path_exists(path):

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -82,6 +82,7 @@ def init_app(app, statsd_client=None):
     ensure_log_path_exists(app.config['NOTIFY_LOG_PATH'])
     the_handler = get_handler(app)
 
+    # Add to see log level while running local 
     loglevel = logging.getLevelName(app.config['NOTIFY_LOG_LEVEL'])
     print("This is the log level", loglevel)
 
@@ -89,6 +90,7 @@ def init_app(app, statsd_client=None):
     for the_logger, handler in product(loggers, [the_handler]):
         the_logger.addHandler(handler)
         the_logger.setLevel(logging.INFO)
+
     logging.getLogger('boto3').setLevel(logging.WARNING)
     logging.getLogger('s3transfer').setLevel(logging.WARNING)
     app.logger.info("Logging configured")

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -47,7 +47,7 @@ def init_app(app, statsd_client=None):
       app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
     else:
       app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
-
+    breakpoint()
     # app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
     app.config.setdefault('NOTIFY_APP_NAME', 'none')
     app.config.setdefault('NOTIFY_LOG_PATH', './log/application.log')

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -46,13 +46,10 @@ def init_app(app, statsd_client=None):
     if app.config['NOTIFY_ENVIRONMENT'] == 'production':
       app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
     else:
-      app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
-    breakpoint()
-    # app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
+      app.config.setdefault('NOTIFY_LOG_LEVEL', 'DEBUG')
+  
     app.config.setdefault('NOTIFY_APP_NAME', 'none')
     app.config.setdefault('NOTIFY_LOG_PATH', './log/application.log')
-
-    print("WHAT IS NOTIFY_LOG_LEVEL 1", app.config['NOTIFY_LOG_LEVEL'])
 
     @app.after_request
     def after_request(response):
@@ -89,15 +86,12 @@ def init_app(app, statsd_client=None):
     ensure_log_path_exists(app.config['NOTIFY_LOG_PATH'])
     the_handler = get_handler(app)
 
-    # Add to see log level while running local 
     loglevel = logging.getLevelName(app.config['NOTIFY_LOG_LEVEL'])
-    print("WHAT IS NOTIFY_LOG_LEVEL 2", app.config['NOTIFY_LOG_LEVEL'])
 
     loggers = [app.logger, logging.getLogger('utils')]
     for the_logger, handler in product(loggers, [the_handler]):
         the_logger.addHandler(handler)
         the_logger.setLevel(loglevel)
-        print("WHAT IS LOG LEVEL FOR the_logger", the_logger.level)
 
     logging.getLogger('boto3').setLevel(logging.WARNING)
     logging.getLogger('s3transfer').setLevel(logging.WARNING)
@@ -129,8 +123,6 @@ def get_handler(app):
     stream_handler.setLevel(logging.getLevelName(app.config['NOTIFY_LOG_LEVEL']))
     stream_handler.addFilter(AppNameFilter(app.config['NOTIFY_APP_NAME']))
     stream_handler.addFilter(RequestIdFilter())
-
-    print("WHAT IS THE stream_handler", stream_handler.__dict__)
 
     if app.debug:
         # Human readable stdout logs that omit static route 200 responses

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -1,5 +1,6 @@
 from email.mime import application
 import logging
+import os
 import sys
 from flask import request, g
 from flask.ctx import has_request_context
@@ -44,7 +45,7 @@ def build_statsd_line(extra_fields):
 
 def init_app(app, statsd_client=None):
 
-    if app.config['NOTIFY_ENVIRONMENT'] == 'production':
+    if os.environ['NOTIFY_ENVIRONMENT'] == 'production':
       app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
     else:
       app.config.setdefault('NOTIFY_LOG_LEVEL', 'DEBUG')

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -42,13 +42,12 @@ def build_statsd_line(extra_fields):
 
 
 def init_app(app, statsd_client=None):
-    return False
+
     app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
     app.config.setdefault('NOTIFY_APP_NAME', 'none')
     app.config.setdefault('NOTIFY_LOG_PATH', './log/application.log')
 
-    if True:
-        raise ValueError(f"IN NOTIFICATION-UTILS: NOTIFY_LOG_LEVEL value = {app.config['NOTIFY_LOG_LEVEL']}, app.logging level = {app.logging.level}")
+    print("WHAT IS NOTIFY_LOG_LEVEL 1", app.config['NOTIFY_LOG_LEVEL'])
 
     @app.after_request
     def after_request(response):
@@ -87,12 +86,13 @@ def init_app(app, statsd_client=None):
 
     # Add to see log level while running local 
     loglevel = logging.getLevelName(app.config['NOTIFY_LOG_LEVEL'])
-    print("This is the log level", loglevel)
+    print("WHAT IS NOTIFY_LOG_LEVEL 2", app.config['NOTIFY_LOG_LEVEL'])
 
     loggers = [app.logger, logging.getLogger('utils')]
     for the_logger, handler in product(loggers, [the_handler]):
         the_logger.addHandler(handler)
         the_logger.setLevel(loglevel)
+        print("WHAT IS LOG LEVEL FOR the_logger", the_logger.level)
 
     logging.getLogger('boto3').setLevel(logging.WARNING)
     logging.getLogger('s3transfer').setLevel(logging.WARNING)
@@ -124,6 +124,8 @@ def get_handler(app):
     stream_handler.setLevel(logging.getLevelName(app.config['NOTIFY_LOG_LEVEL']))
     stream_handler.addFilter(AppNameFilter(app.config['NOTIFY_APP_NAME']))
     stream_handler.addFilter(RequestIdFilter())
+
+    print("WHAT IS THE stream_handler", stream_handler.__dict__)
 
     if app.debug:
         # Human readable stdout logs that omit static route 200 responses

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -46,6 +46,10 @@ def init_app(app, statsd_client=None):
     app.config.setdefault('NOTIFY_APP_NAME', 'none')
     app.config.setdefault('NOTIFY_LOG_PATH', './log/application.log')
 
+    print("HIT NOTIFICATION-UTILS LOGGING INIT_APP")
+    print("NOTIFICATION-UTILS LOG LEVEL:", app.logging.level)
+    print("NOTIFICATION-UTILS NOTIFY_LOG_LEVEL", app.config['NOTIFY_LOG_LEVEL'])
+
     @app.after_request
     def after_request(response):
         extra_fields = {

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -42,7 +42,13 @@ def build_statsd_line(extra_fields):
 
 
 def init_app(app, statsd_client=None):
-    app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
+
+    if app.config['NOTIFY_ENVIRONMENT'] == 'production':
+      app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
+    else:
+      app.config.setdefault('NOTIFY_LOG_LEVEL', 'DEBUG')
+
+    # app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
     app.config.setdefault('NOTIFY_APP_NAME', 'none')
     app.config.setdefault('NOTIFY_LOG_PATH', './log/application.log')
 

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -45,13 +45,12 @@ def build_statsd_line(extra_fields):
 
 def init_app(app, statsd_client=None):
 
+    # For production environment, set log level to INFO 
+    # For all other environment, set log level to DEBUG
     if os.environ['NOTIFY_ENVIRONMENT'] == 'production':
       app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
     else:
       app.config.setdefault('NOTIFY_LOG_LEVEL', 'DEBUG')
-    
-    print("NOTIFCATION-UTILS WHAT IS NOTIFY_ENVIRONMENT", os.environ['NOTIFY_ENVIRONMENT'])
-    print("NOTIFICATION-UTILS WHAT IS NOTIFY_LOG_LEVEL", app.config['NOTIFY_LOG_LEVEL'] )
   
     app.config.setdefault('NOTIFY_APP_NAME', 'none')
     app.config.setdefault('NOTIFY_LOG_PATH', './log/application.log')
@@ -90,19 +89,15 @@ def init_app(app, statsd_client=None):
 
     ensure_log_path_exists(app.config['NOTIFY_LOG_PATH'])
     the_handler = get_handler(app)
-
     loglevel = logging.getLevelName(app.config['NOTIFY_LOG_LEVEL'])
-
     loggers = [app.logger, logging.getLogger('utils')]
     for the_logger, handler in product(loggers, [the_handler]):
         the_logger.addHandler(handler)
         the_logger.setLevel(loglevel)
-
     logging.getLogger('boto3').setLevel(logging.WARNING)
     logging.getLogger('s3transfer').setLevel(logging.WARNING)
 
-    print("NOTIFICATION-UTILS WHAT APPLICATION.LOGGER.LEVEL", app.logger.level)
-    app.logger.info("Logging configured")
+    app.logger.info("Logging configured. The log level has been set to %s", app.logger.level) 
 
 
 def ensure_log_path_exists(path):

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -1,12 +1,14 @@
 import logging
 import os
 import sys
-from flask import request, g
-from flask.ctx import has_request_context
 from itertools import product
 from pathlib import Path
-from pythonjsonlogger.jsonlogger import JsonFormatter
 from time import monotonic
+
+from flask import request, g
+from flask.ctx import has_request_context
+from pythonjsonlogger.jsonlogger import JsonFormatter
+
 
 # The "application" and "requestId" fields are non-standard LogRecord attributes added below in the
 # "get_handler" function via filters.  If this causes errors, logging is misconfigured.

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -95,8 +95,10 @@ def init_app(app, statsd_client=None):
 
 
 def set_log_level(app):
-    # For production environment, set log level to INFO
-    # For all other environment, set log level to DEBUG
+    """
+    For production environment, set log level to INFO.
+    For all other environment, set log level to DEBUG.
+    """
     if os.environ['NOTIFY_ENVIRONMENT'] == 'production':
         app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
     else:

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -43,7 +43,12 @@ def build_statsd_line(extra_fields):
 
 def init_app(app, statsd_client=None):
 
-    app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
+    if app.config['NOTIFY_ENVIRONMENT'] == 'production':
+      app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
+    else:
+      app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
+    breakpoint()
+    # app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
     app.config.setdefault('NOTIFY_APP_NAME', 'none')
     app.config.setdefault('NOTIFY_LOG_PATH', './log/application.log')
 

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -46,9 +46,8 @@ def init_app(app, statsd_client=None):
     app.config.setdefault('NOTIFY_APP_NAME', 'none')
     app.config.setdefault('NOTIFY_LOG_PATH', './log/application.log')
 
-    print("HIT NOTIFICATION-UTILS LOGGING INIT_APP")
-    print("NOTIFICATION-UTILS LOG LEVEL:", app.logging.level)
-    print("NOTIFICATION-UTILS NOTIFY_LOG_LEVEL", app.config['NOTIFY_LOG_LEVEL'])
+    if True:
+        raise ValueError(f"IN NOTIFICATION-UTILS: NOTIFY_LOG_LEVEL value = {app.config['NOTIFY_LOG_LEVEL']}, app.logging level = {app.logging.level}")
 
     @app.after_request
     def after_request(response):

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -81,8 +81,10 @@ def init_app(app, statsd_client=None):
 
     ensure_log_path_exists(app.config['NOTIFY_LOG_PATH'])
     the_handler = get_handler(app)
+
     loglevel = logging.getLevelName(app.config['NOTIFY_LOG_LEVEL'])
     print("This is the log level", loglevel)
+
     loggers = [app.logger, logging.getLogger('utils')]
     for the_logger, handler in product(loggers, [the_handler]):
         the_logger.addHandler(handler)
@@ -115,7 +117,9 @@ def is_200_static_log(log) -> bool:
 def get_handler(app):
     stream_handler = logging.StreamHandler(sys.stdout)
 
+    # stream_handler.setLevel(logging.getLevelName(app.config['NOTIFY_LOG_LEVEL']))
     stream_handler.setLevel(logging.getLevelName(app.config['NOTIFY_LOG_LEVEL']))
+    print("THIS IS THE APPNAMEFILTER variable", logging.getLevelName(app.config['NOTIFY_LOG_LEVEL']))
     stream_handler.addFilter(AppNameFilter(app.config['NOTIFY_APP_NAME']))
     stream_handler.addFilter(RequestIdFilter())
 

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -117,13 +117,12 @@ def is_200_static_log(log) -> bool:
 def get_handler(app):
     stream_handler = logging.StreamHandler(sys.stdout)
 
-    # stream_handler.setLevel(logging.getLevelName(app.config['NOTIFY_LOG_LEVEL']))
     stream_handler.setLevel(logging.getLevelName(app.config['NOTIFY_LOG_LEVEL']))
-    print("THIS IS THE APPNAMEFILTER variable", logging.getLevelName(app.config['NOTIFY_LOG_LEVEL']))
     stream_handler.addFilter(AppNameFilter(app.config['NOTIFY_APP_NAME']))
     stream_handler.addFilter(RequestIdFilter())
 
     if app.debug:
+        print("debug is true")
         # Human readable stdout logs that omit static route 200 responses
         logging.getLogger('werkzeug').addFilter(is_200_static_log)
         stream_handler.setFormatter(logging.Formatter(LOG_FORMAT, TIME_FORMAT))

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -46,7 +46,7 @@ def init_app(app, statsd_client=None):
     if app.config['NOTIFY_ENVIRONMENT'] == 'production':
       app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
     else:
-      app.config.setdefault('NOTIFY_LOG_LEVEL', 'DEBUG')
+      app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
 
     # app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
     app.config.setdefault('NOTIFY_APP_NAME', 'none')
@@ -87,6 +87,7 @@ def init_app(app, statsd_client=None):
     ensure_log_path_exists(app.config['NOTIFY_LOG_PATH'])
     the_handler = get_handler(app)
     loglevel = logging.getLevelName(app.config['NOTIFY_LOG_LEVEL'])
+    print("This is the log level", loglevel)
     loggers = [app.logger, logging.getLogger('utils')]
     for the_logger, handler in product(loggers, [the_handler]):
         the_logger.addHandler(handler)

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -1,3 +1,4 @@
+from email.mime import application
 import logging
 import sys
 from flask import request, g
@@ -47,6 +48,9 @@ def init_app(app, statsd_client=None):
       app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
     else:
       app.config.setdefault('NOTIFY_LOG_LEVEL', 'DEBUG')
+    
+    print("NOTIFCATION-UTILS WHAT IS NOTIFY_ENVIRONMENT", app.config['NOTIFY_ENVIRONMENT'] )
+    print("NOTIFICATION-UTILS WHAT IS NOTIFY_LOG_LEVEL", app.config['NOTIFY_LOG_LEVEL'] )
   
     app.config.setdefault('NOTIFY_APP_NAME', 'none')
     app.config.setdefault('NOTIFY_LOG_PATH', './log/application.log')
@@ -95,6 +99,8 @@ def init_app(app, statsd_client=None):
 
     logging.getLogger('boto3').setLevel(logging.WARNING)
     logging.getLogger('s3transfer').setLevel(logging.WARNING)
+
+    print("NOTIFICATION-UTILS WHAT APPLICATION.LOGGER.LEVEL", app.logger.level)
     app.logger.info("Logging configured")
 
 

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -43,12 +43,7 @@ def build_statsd_line(extra_fields):
 
 def init_app(app, statsd_client=None):
 
-    if app.config['NOTIFY_ENVIRONMENT'] == 'production':
-      app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
-    else:
-      app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
-    breakpoint()
-    # app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
+    app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
     app.config.setdefault('NOTIFY_APP_NAME', 'none')
     app.config.setdefault('NOTIFY_LOG_PATH', './log/application.log')
 
@@ -119,6 +114,12 @@ def is_200_static_log(log) -> bool:
 
 def get_handler(app):
     stream_handler = logging.StreamHandler(sys.stdout)
+    
+    if app.config['NOTIFY_ENVIRONMENT'] == 'production':
+      app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
+    else:
+      app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
+
     stream_handler.setLevel(logging.getLevelName(app.config['NOTIFY_LOG_LEVEL']))
     stream_handler.addFilter(AppNameFilter(app.config['NOTIFY_APP_NAME']))
     stream_handler.addFilter(RequestIdFilter())

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -42,7 +42,6 @@ def build_statsd_line(extra_fields):
 
 
 def init_app(app, statsd_client=None):
-
     app.config.setdefault('NOTIFY_LOG_LEVEL', 'INFO')
     app.config.setdefault('NOTIFY_APP_NAME', 'none')
     app.config.setdefault('NOTIFY_LOG_PATH', './log/application.log')
@@ -89,7 +88,7 @@ def init_app(app, statsd_client=None):
     loggers = [app.logger, logging.getLogger('utils')]
     for the_logger, handler in product(loggers, [the_handler]):
         the_logger.addHandler(handler)
-        the_logger.setLevel(logging.INFO)
+        the_logger.setLevel(loglevel)
 
     logging.getLogger('boto3').setLevel(logging.WARNING)
     logging.getLogger('s3transfer').setLevel(logging.WARNING)
@@ -118,13 +117,11 @@ def is_200_static_log(log) -> bool:
 
 def get_handler(app):
     stream_handler = logging.StreamHandler(sys.stdout)
-
     stream_handler.setLevel(logging.getLevelName(app.config['NOTIFY_LOG_LEVEL']))
     stream_handler.addFilter(AppNameFilter(app.config['NOTIFY_APP_NAME']))
     stream_handler.addFilter(RequestIdFilter())
 
     if app.debug:
-        print("debug is true")
         # Human readable stdout logs that omit static route 200 responses
         logging.getLogger('werkzeug').addFilter(is_200_static_log)
         stream_handler.setFormatter(logging.Formatter(LOG_FORMAT, TIME_FORMAT))

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -22,8 +22,8 @@ function display_result {
   fi
 }
 
-# flake8 --config .flake8 .
-# display_result $? 1 "Code style check"
+flake8 --config .flake8 .
+display_result $? 1 "Code style check"
 
 ## Code coverage
 #py.test --cov=client tests/

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -22,8 +22,8 @@ function display_result {
   fi
 }
 
-flake8 --config .flake8 .
-display_result $? 1 "Code style check"
+# flake8 --config .flake8 .
+# display_result $? 1 "Code style check"
 
 ## Code coverage
 #py.test --cov=client tests/

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,5 +1,6 @@
 import json
 import logging as builtin_logging
+import os
 import uuid
 from notifications_utils import logging
 from pythonjsonlogger.jsonlogger import JsonFormatter
@@ -159,3 +160,30 @@ def test_get_handler_sets_up_logging_appropriately_without_debug(tmpdir):
     assert message_dict["message"] == "Hello, Cornelius.  Line 42."
     assert message_dict["pathname"] == "the_path"
     assert message_dict["lineno"] == 1999
+
+
+class App:
+    def __init__(self):
+        self.config = {}
+
+def reset_environment(app):
+    os.environ.pop('NOTIFY_ENVIRONMENT', None)
+    app.config.pop('NOTIFY_LOG_LEVEL', None)
+
+def test_set_log_level_production():
+    app = App()
+    os.environ['NOTIFY_ENVIRONMENT'] = 'production'
+    
+    logging.set_log_level(app)
+    assert app.config['NOTIFY_LOG_LEVEL'] == 'INFO'
+    
+    reset_environment(app)
+
+def test_set_log_level_non_production():
+    app = App()
+    os.environ['NOTIFY_ENVIRONMENT'] = 'development'
+    
+    logging.set_log_level(app)
+    assert app.config['NOTIFY_LOG_LEVEL'] == 'DEBUG'
+    
+    reset_environment(app)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -120,8 +120,8 @@ def test_should_build_statsd_line_without_service_id_or_time_taken():
 
 def test_get_handler_sets_up_logging_appropriately_with_debug(tmpdir, app):
     del app.config['NOTIFY_LOG_PATH']
+
     app.debug = True
-    
     handler = logging.get_handler(app)
 
     assert type(handler) == builtin_logging.StreamHandler
@@ -173,7 +173,7 @@ def test_get_handler_sets_up_logging_appropriately_without_debug(app):
 
 
 def test_it_set_log_level_production(app, reset_environment):
-    del app.config['NOTIFY_LOG_LEVEL'] 
+    del app.config['NOTIFY_LOG_LEVEL']
 
     os.environ['NOTIFY_ENVIRONMENT'] = 'production'
     logging.set_log_level(app)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,8 +2,34 @@ import json
 import logging as builtin_logging
 import os
 import uuid
+import pytest
 from notifications_utils import logging
 from pythonjsonlogger.jsonlogger import JsonFormatter
+
+
+class App:
+    def __init__(self, config=None, debug=False):
+        self.config = config or {}
+        self.debug = debug
+
+
+@pytest.fixture(autouse=True)
+def app(tmpdir, debug=True):
+    return App(config={
+        'NOTIFY_LOG_PATH': str(tmpdir / 'foo'),
+        'NOTIFY_APP_NAME': 'bar',
+        'NOTIFY_LOG_LEVEL': 'DEBUG',
+    }, debug=debug)
+
+
+@pytest.fixture(autouse=True)
+def reset_environment():
+    original_env = os.environ.get('NOTIFY_ENVIRONMENT', None)
+    yield
+    if original_env is not None:
+        os.environ['NOTIFY_ENVIRONMENT'] = original_env
+    else:
+        os.environ.pop('NOTIFY_ENVIRONMENT', None)
 
 
 def test_should_build_complete_log_line():
@@ -92,17 +118,10 @@ def test_should_build_statsd_line_without_service_id_or_time_taken():
     assert logging.build_statsd_line(extra_fields) == "method.endpoint.200"
 
 
-def test_get_handler_sets_up_logging_appropriately_with_debug(tmpdir):
-    class App:
-        config = {
-            'NOTIFY_LOG_PATH': str(tmpdir / 'foo'),
-            'NOTIFY_APP_NAME': 'bar',
-            'NOTIFY_LOG_LEVEL': 'ERROR'
-        }
-        debug = True
-
-    app = App()
-
+def test_get_handler_sets_up_logging_appropriately_with_debug(tmpdir, app):
+    del app.config['NOTIFY_LOG_PATH']
+    app.debug = True
+    
     handler = logging.get_handler(app)
 
     assert type(handler) == builtin_logging.StreamHandler
@@ -124,17 +143,8 @@ def test_get_handler_sets_up_logging_appropriately_with_debug(tmpdir):
     assert message.endswith(f' {application} the_name debug id "Hello, Cornelius.  Line 42." [in the_path:1999]')
 
 
-def test_get_handler_sets_up_logging_appropriately_without_debug(tmpdir):
-    class App:
-        config = {
-            # make a tempfile called foo
-            'NOTIFY_LOG_PATH': str(tmpdir / 'foo'),
-            'NOTIFY_APP_NAME': 'bar',
-            'NOTIFY_LOG_LEVEL': 'ERROR'
-        }
-        debug = False
-
-    app = App()
+def test_get_handler_sets_up_logging_appropriately_without_debug(app):
+    app.debug = False
     handler = logging.get_handler(app)
     assert type(handler) == builtin_logging.StreamHandler
     assert type(handler.formatter) == JsonFormatter
@@ -162,28 +172,15 @@ def test_get_handler_sets_up_logging_appropriately_without_debug(tmpdir):
     assert message_dict["lineno"] == 1999
 
 
-class App:
-    def __init__(self):
-        self.config = {}
+def test_set_log_level_production(app, reset_environment):
+    del app.config['NOTIFY_LOG_LEVEL'] 
 
-def reset_environment(app):
-    os.environ.pop('NOTIFY_ENVIRONMENT', None)
-    app.config.pop('NOTIFY_LOG_LEVEL', None)
-
-def test_set_log_level_production():
-    app = App()
     os.environ['NOTIFY_ENVIRONMENT'] = 'production'
-    
     logging.set_log_level(app)
     assert app.config['NOTIFY_LOG_LEVEL'] == 'INFO'
-    
-    reset_environment(app)
 
-def test_set_log_level_non_production():
-    app = App()
+
+def test_set_log_level_non_production(app, reset_environment):
     os.environ['NOTIFY_ENVIRONMENT'] = 'development'
-    
     logging.set_log_level(app)
     assert app.config['NOTIFY_LOG_LEVEL'] == 'DEBUG'
-    
-    reset_environment(app)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,6 +2,7 @@ import json
 import logging as builtin_logging
 import os
 import uuid
+
 import pytest
 from notifications_utils import logging
 from pythonjsonlogger.jsonlogger import JsonFormatter

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -172,7 +172,7 @@ def test_get_handler_sets_up_logging_appropriately_without_debug(app):
     assert message_dict["lineno"] == 1999
 
 
-def test_set_log_level_production(app, reset_environment):
+def test_it_set_log_level_production(app, reset_environment):
     del app.config['NOTIFY_LOG_LEVEL'] 
 
     os.environ['NOTIFY_ENVIRONMENT'] = 'production'
@@ -180,7 +180,7 @@ def test_set_log_level_production(app, reset_environment):
     assert app.config['NOTIFY_LOG_LEVEL'] == 'INFO'
 
 
-def test_set_log_level_non_production(app, reset_environment):
+def test_it_set_log_level_non_production(app, reset_environment):
     os.environ['NOTIFY_ENVIRONMENT'] = 'development'
     logging.set_log_level(app)
     assert app.config['NOTIFY_LOG_LEVEL'] == 'DEBUG'


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description

Issue #146 

- Update logic in `logger.py` `init_app` method to set log levels to `INFO` if production, else `DEBUG` is not.
- Update unit testing

## Type of change

Please check the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation changes only
- [x] Internal

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)

- Ran locally with Postman. I toggled the environment from `production` to `development` and confirmed the logging level changed according to the environment. 
- Deployed `notification-api` to DEV with the dependency for `notification-utils` referencing this feature branch (146-update_debug_log_level ). Confirmed that DEV logs now showed DEBUG logs.  [See the branch I used for testing here. ](https://github.com/department-of-veterans-affairs/notification-api/pull/1843)

![image](https://github.com/department-of-veterans-affairs/notification-utils/assets/16658577/ee361e0e-deb3-4f5e-be05-43408aded0f0)
![image](https://github.com/department-of-veterans-affairs/notification-utils/assets/16658577/2ce4b1a5-daf1-4943-8be5-fd3cd37e30ea)


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an appropriate title: #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/master/.github/release.yaml) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have ensured the latest master is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [N/A] Any dependent changes have been merged and published in downstream modules
- [x] The ticket is now moved into the DEV test column
