### PR TITLE
#159 Add an alt attribute for the GA4 tracker image

### DIFF
--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -219,7 +219,7 @@
 <img id="ga_pixel_url" src="{{ ga_pixel_url }}" />
 {% endif %}
 {% if ga4_open_email_event_url %}
-<img id="ga4_open_email_event_url" src="{{ ga4_open_email_event_url }}" />
+<img id="ga4_open_email_event_url" src="{{ ga4_open_email_event_url }}" alt="" />
 {% endif %}
 {% if complete_html %}
 </body>


### PR DESCRIPTION
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/alt

Adding an image "alt" attribute with an empty string value tells the browser not to display a broken image link.