### PR TITLE
fix: email preview when zoomed in

### DIFF
--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -26,6 +26,15 @@
             margin-left: auto;
             margin-right: auto;
             display: block;
+            max-height: 36px;
+        }
+
+        td {
+            word-break: break-word;
+        }
+
+        blockquote {
+            padding: 8px 8px 0.1px 8px;
         }
     }
     body { Margin:0 !important; }


### PR DESCRIPTION
# Summary | Résumé

In order for the portal to meet accessibility standards, it needs to be responsive to zoom and be usable at 200%, 300%, and 400% zoom. 

The email preview on the portal, including opening an existing email template, the Preview tab during email creation, and the page that loads immediately after a template is created are not zoom responsive. As the zoom level is increased, the content of the email is cutoff by page margins.

## Related Issues | Cartes liées

[#2725: Email Preview Not Responsive to Zooming](https://github.com/orgs/department-of-veterans-affairs/projects/1415/views/1?pane=issue&itemId=97476962&issue=department-of-veterans-affairs%7Cnotification-portal%7C2725)

# Test instructions | Instructions pour tester la modification

tbd

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.